### PR TITLE
Certificates block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "drupal/twig_tweak": "^2.4",
     "drupal/union_organizer": "dev-master",
     "drush/drush": "^9.0.0",
-    "npm-asset/cornell_ilr--union": "^0.2.8",
+    "npm-asset/cornell_ilr--union": "^0.2.9",
     "oomphinc/composer-installers-extender": "^1.1",
     "platformsh/config-reader": "^2.3",
     "vlucas/phpdotenv": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b9594a6f088b496c38fa6e15e2158b4",
+    "content-hash": "0f92d4d7ee31af43e0a527655b709897",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -4161,7 +4161,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.4",
-                    "datestamp": "1563099329",
+                    "datestamp": "1563096785",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5161,10 +5161,10 @@
         },
         {
             "name": "npm-asset/cornell_ilr--union",
-            "version": "0.2.8",
+            "version": "0.2.9",
             "dist": {
                 "type": "tar",
-                "url": "https://registry.npmjs.org/@cornell_ilr/union/-/union-0.2.8.tgz"
+                "url": "https://registry.npmjs.org/@cornell_ilr/union/-/union-0.2.9.tgz"
             },
             "type": "npm-asset",
             "license": [

--- a/config/sync/views.view.certificates.yml
+++ b/config/sync/views.view.certificates.yml
@@ -1,0 +1,255 @@
+uuid: 7a08f265-d0e2-4011-9702-ba7d4b0826bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.certificate
+  module:
+    - node
+    - text
+    - user
+id: certificates
+label: Certificates
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          items_per_page: 0
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: summary
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 300
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            certificate: certificate
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          order: ASC
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+      title: Certificates
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+  block:
+    display_plugin: block
+    id: block
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'

--- a/web/themes/custom/union_marketing/scss/components/_feature-list.scss
+++ b/web/themes/custom/union_marketing/scss/components/_feature-list.scss
@@ -1,0 +1,10 @@
+// Include union overrides here for feature lists
+.certificate-list {
+  .cu-feature-list__item {
+    margin-bottom: var(--cu-vr1);
+  }
+
+  .cu-feature-list__description {
+    --cu-current-font-size: var(--cu-ms-1);
+  }
+}

--- a/web/themes/custom/union_marketing/scss/style.scss
+++ b/web/themes/custom/union_marketing/scss/style.scss
@@ -14,3 +14,4 @@
 @import "layout/one-column";
 @import "components/navigation";
 @import "components/fields";
+@import "components/feature-list";

--- a/web/themes/custom/union_marketing/templates/block/block--views-block--certificates-block.html.twig
+++ b/web/themes/custom/union_marketing/templates/block/block--views-block--certificates-block.html.twig
@@ -1,0 +1,59 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+
+{# @todo: Refactor to use a views template once views template suggestions working #}
+
+{# Use the certificates view result rows to transform the certificates #}
+{% set certificate_results = drupal_view_result('certificates', 'block') %}
+{% set certificates = [] %}
+{% for result in certificate_results %}
+  {% set cert = {
+    name: result._entity.label,
+    link: path('entity.node.canonical', {'node': result.nid}),
+    description: result._entity.body.summary
+  } %}
+  {% set certificates = certificates|merge([cert]) %}
+{% endfor %}
+
+{# Create a grid #}
+{% set certificate_grid %}
+  {% include "@union/_feature-list.twig" with {
+    items: certificates,
+    content_attributes: { class: 'cu-grid--2col cu-certificate-list' }
+  } only %}
+{% endset %}
+
+{% include '@union/_section-heading.twig' with {
+  attributes: { class: 'cu-section-heading--framed', id: 'related-courses' },
+  heading: 'Certificates'|t,
+  subheading: 'Professional'|t
+} only %}
+
+<div class="certificate-list">
+  {{ certificate_grid }}
+</div>


### PR DESCRIPTION
Zach has requested a page where we can list all certificates, similar to [the current page](https://www.ilr.cornell.edu/programs/professional-programs/certificate-programs). 

To test, you'll need to add the certificates block on a page node, using the layout tab. I published a new version of union regardless, since we should have done that sooner anyway.