### PR TITLE
Google tag manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     "drupal/easy_breadcrumb": "^1.12",
     "drupal/entity_reference_layout": "1.x-dev",
     "drupal/facets": "^1.4",
+    "drupal/google_tag": "^1.2",
     "drupal/metatag": "^1.10",
     "drupal/migrate_file": "^1.1",
     "drupal/migrate_plus": "^4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60adf31ac60023de7e3c02d3d563d909",
+    "content-hash": "7a897df44448710388121432d7a7dfca",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -1210,6 +1210,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
@@ -3388,6 +3389,53 @@
             }
         },
         {
+            "name": "drupal/google_tag",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/google_tag.git",
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/google_tag-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "7ea79c9bab4ac7692c998c35452c82a36b2827bd"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.2",
+                    "datestamp": "1573067711",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL 2.0"
+            ],
+            "authors": [
+                {
+                    "name": "solotandem",
+                    "homepage": "https://www.drupal.org/user/240748"
+                }
+            ],
+            "description": "Allows your website analytics to be managed using Google Tag Manager.",
+            "homepage": "https://www.drupal.org/project/google_tag",
+            "support": {
+                "source": "https://git.drupalcode.org/project/google_tag"
+            }
+        },
+        {
             "name": "drupal/key",
             "version": "1.10.0",
             "source": {
@@ -4392,7 +4440,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.4",
-                    "datestamp": "1563096785",
+                    "datestamp": "1563099329",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/config/prod/.htaccess
+++ b/config/prod/.htaccess
@@ -1,0 +1,24 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>

--- a/config/prod/google_tag.container.ilr_default.yml
+++ b/config/prod/google_tag.container.ilr_default.yml
@@ -1,0 +1,21 @@
+uuid: e2254315-b7bc-409e-965b-567ebb1149ca
+langcode: en
+status: true
+dependencies: {  }
+id: ilr_default
+label: 'ILR Default'
+weight: 0
+container_id: GTM-N966MM
+path_toggle: 'exclude listed'
+path_list: "/admin*\n/batch*\n/node/add*\n/node/*/edit\n/node/*/delete\n/user/*/edit*\n/user/*/cancel*"
+role_toggle: 'exclude listed'
+role_list: {  }
+status_toggle: 'exclude listed'
+status_list: "403\n404"
+data_layer: dataLayer
+include_classes: 0
+whitelist_classes: "google\nnonGooglePixels\nnonGoogleScripts\nnonGoogleIframes"
+blacklist_classes: "customScripts\ncustomPixels"
+include_environment: 0
+environment_id: ''
+environment_token: ''

--- a/config/prod/google_tag.settings.yml
+++ b/config/prod/google_tag.settings.yml
@@ -1,0 +1,22 @@
+uri: 'public://google_tag'
+compact_snippet: true
+include_file: true
+rebuild_snippets: true
+debug_output: false
+_default_container:
+  container_id: ''
+  path_toggle: 'exclude listed'
+  path_list: "/admin*\n/batch*\n/node/add*\n/node/*/edit\n/node/*/delete\n/user/*/edit*\n/user/*/cancel*"
+  role_toggle: 'exclude listed'
+  role_list: {  }
+  status_toggle: 'exclude listed'
+  status_list: "403\n404"
+  data_layer: dataLayer
+  include_classes: false
+  whitelist_classes: "google\nnonGooglePixels\nnonGoogleScripts\nnonGoogleIframes"
+  blacklist_classes: "customScripts\ncustomPixels"
+  include_environment: false
+  environment_id: ''
+  environment_token: ''
+_core:
+  default_config_hash: dIZsh-f5gE1BcuZjI3nIz5gsss2nfMynKKcVFw77a1s

--- a/config/sync/config_split.config_split.production.yml
+++ b/config/sync/config_split.config_split.production.yml
@@ -1,0 +1,16 @@
+uuid: 26fc0b7c-04c4-4677-8020-b86da6d3cf2c
+langcode: en
+status: false
+dependencies: {  }
+id: production
+label: Production
+description: 'Modules and configuration that should only be enabled on the production site. Examples include Google Tag Manager (GTM), SimpleSAML authentication, etc.'
+folder: ../config/prod
+module:
+  google_tag: 0
+theme: {  }
+blacklist: {  }
+graylist: {  }
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 0

--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -165,3 +165,8 @@ $settings['hash_salt'] = $settings['hash_salt'] ?? $platformsh->projectEntropy;
 
 // Set the deployment identifier, which is used by some Drupal cache systems.
 $settings['deployment_identifier'] = $settings['deployment_identifier'] ?? $platformsh->treeId;
+
+if ($platformsh->onProduction()) {
+  // Enable the config split for production-only modules.
+  $config['config_split.config_split.production']['status'] = TRUE;
+}


### PR DESCRIPTION
This adds the google_tag module to a new `production` config split, which is only ever activated on the platform.sh production environment.