### PR TITLE
Updating section to support setting the new right variant.

### DIFF
--- a/web/modules/custom/ilr/src/Plugin/paragraphs/Behavior/UnionSectionSettings.php
+++ b/web/modules/custom/ilr/src/Plugin/paragraphs/Behavior/UnionSectionSettings.php
@@ -33,6 +33,17 @@ class UnionSectionSettings extends ParagraphsBehaviorBase {
   ];
 
   /**
+   * The header alignment options.
+   *
+   * @var array
+   */
+  protected $headerAlignment = [
+    '' => 'Default',
+    'left' => 'Left',
+    'right' => 'Right',
+  ];
+
+  /**
    * {@inheritdoc}
    */
   public function buildBehaviorForm(ParagraphInterface $paragraph, array &$form, FormStateInterface $form_state) {
@@ -48,11 +59,11 @@ class UnionSectionSettings extends ParagraphsBehaviorBase {
       '#default_value' => $paragraph->getBehaviorSetting($this->getPluginId(), 'wide'),
     ];
 
-    $form['heading_left'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Place heading on left'),
-      '#min' => 1,
-      '#default_value' => $paragraph->getBehaviorSetting($this->getPluginId(), 'heading_left'),
+    $form['header_alignment'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Header alignment'),
+      '#options' => $this->headerAlignment,
+      '#default_value' => $paragraph->getBehaviorSetting($this->getPluginId(), 'header_alignment') ?? '',
     ];
 
     $form['first_component_to_blurb'] = [
@@ -84,8 +95,8 @@ class UnionSectionSettings extends ParagraphsBehaviorBase {
       $variables['attributes']['class'][] = 'cu-section--wide';
     }
 
-    if ($variables['paragraph']->getBehaviorSetting($this->getPluginId(), 'heading_left')) {
-      $variables['attributes']['class'][] = 'cu-section--left';
+    if ($header_alignment = $variables['paragraph']->getBehaviorSetting($this->getPluginId(), 'header_alignment')) {
+      $variables['attributes']['class'][] = 'cu-section--' . $header_alignment;
     }
 
     if ($frame_position = $variables['paragraph']->getBehaviorSetting($this->getPluginId(), 'frame_position')) {
@@ -120,6 +131,14 @@ class UnionSectionSettings extends ParagraphsBehaviorBase {
       $summary[] = [
         'label' => 'Wide',
         'value' => '✓',
+      ];
+    }
+
+    // Display header alignment settings.
+    if ($header_alignment = $paragraph->getBehaviorSetting($this->getPluginId(), 'header_alignment')) {
+      $summary[] = [
+        'label' => 'Header alignment',
+        'value' => $this->headerAlignment[$header_alignment],
       ];
     }
 

--- a/web/themes/custom/union_marketing/scss/components/_sections.scss
+++ b/web/themes/custom/union_marketing/scss/components/_sections.scss
@@ -48,6 +48,65 @@ figure.cu-media,
   // overflow: hidden; // TODO deal with effects on inner block element margins (e.g. blockquote)
 }
 
+// Red frame styling for images within wide left sections
+.cu-section--wide.cu-section--left, .cu-section--wide.cu-section--right {
+  .cu-component--image {
+    position: relative;
+    padding: 8px;
+    margin: 0;
+
+    .cu-image {
+      position: relative;
+      z-index: 1;
+    }
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      background: var(--cu-color-brand, #{$cornell-red});
+      z-index: 0;
+    }
+  }
+
+  &.cu-section--left .cu-component--image {
+    // Horizontal bar (top right edge)
+    &::before {
+      top: 0;
+      right: 0;
+      width: 75%;
+      height: 8px;
+    }
+
+    // Vertical bar (right/bottom edge)
+    &::after {
+      bottom: 0;
+      right: 0;
+      width: 10%;
+      height: calc(100% - 8px);
+    }
+  }
+
+  &.cu-section--right .cu-component--image {
+    // Horizontal bar (top left edge)
+    &::before {
+      top: 0;
+      left: 0;
+      width: 75%;
+      height: 8px;
+    }
+
+    // Vertical bar (left/bottom edge)
+    &::after {
+      bottom: 0;
+      left: 0;
+      width: 10%;
+      height: calc(100% - 8px);
+    }
+  }
+}
+
+
 // Clear floats from rich text media for adjacent components (e.g. paragraphs).
 .cu-component--rich-text + .cu-component {
   clear: both;


### PR DESCRIPTION
Adding red boarder when image component is added.

Like before, this depends on the design system update being merged first. The read boarder shows automatically when an image component is added.